### PR TITLE
Correct XML file for `GenerateIPLVChillerElectricEIRPerformanceCurves`

### DIFF
--- a/lib/measures/GenerateIPLVChillerElectricEIRPerformanceCurves/measure.xml
+++ b/lib/measures/GenerateIPLVChillerElectricEIRPerformanceCurves/measure.xml
@@ -3,8 +3,9 @@
   <schema_version>3.1</schema_version>
   <name>generate_iplv_specific_chiller_performance_curves_for_chillers</name>
   <uid>5cd98b4e-ddfe-44ab-9dca-d9885f57a216</uid>
-  <version_id>54887132-3434-4b10-9302-e4167c5b7c3b</version_id>
-  <version_modified>2023-11-29T12:00:00Z</version_modified>
+  <version_id>9eeccbb6-7517-4337-9feb-fcee913c7cf8</version_id>
+  <version_modified>2024-04-24T19:59:05Z</version_modified>
+  <xml_checksum>905C4D50</xml_checksum>
   <class_name>GenerateIPLVChillerElectricEIRPerformanceCurves</class_name>
   <display_name>Generate IPLV-specific Chiller Performance Curves for Chillers (Chiller:Electric:EIR).</display_name>
   <description>This measure generates and assigns a set of performance curves to a chiller object that matches a target description including the chiller's integrated part load value (IPLV) for the Chiller:Electric:EIR model.</description>
@@ -157,8 +158,25 @@
       <value>false</value>
       <datatype>boolean</datatype>
     </attribute>
+    <attribute>
+      <name>Measure Language</name>
+      <value>Python</value>
+      <datatype>string</datatype>
+    </attribute>
   </attributes>
   <files>
+    <file>
+      <filename>LICENSE.md</filename>
+      <filetype>md</filetype>
+      <usage_type>license</usage_type>
+      <checksum>5B9B2817</checksum>
+    </file>
+    <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>36E44E0F</checksum>
+    </file>
     <file>
       <version>
         <software_program>OpenStudio</software_program>
@@ -168,11 +186,19 @@
       <filename>measure.py</filename>
       <filetype>py</filetype>
       <usage_type>script</usage_type>
+      <checksum>9F1E6C3D</checksum>
+    </file>
+    <file>
+      <filename>__init__.py</filename>
+      <filetype>py</filetype>
+      <usage_type>test</usage_type>
+      <checksum>00000000</checksum>
     </file>
     <file>
       <filename>test_measure.py</filename>
       <filetype>py</filetype>
       <usage_type>test</usage_type>
+      <checksum>39045244</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
Fix XML file after running the `openstudio measure -t` command.