### PR TITLE
Create typical building update + SHW Update

### DIFF
--- a/lib/measures/CreateTypicalBuilding/measure.rb
+++ b/lib/measures/CreateTypicalBuilding/measure.rb
@@ -120,6 +120,12 @@ class CreateTypicalBuilding < OpenStudio::Measure::ModelMeasure
     add_space_types_choice.setDefaultValue('TRUE')
     args << add_space_types_choice
 
+    add_swh_choice = OpenStudio::Measure::OSArgument::makeChoiceArgument('add_swh', true_false_os_vector, true)
+    add_swh_choice.setDisplayName('Add Service Water Heating')
+    add_swh_choice.setDescription('Add typical service water heating systems based on space types and building characteristics.')
+    add_swh_choice.setDefaultValue('FALSE')
+    args << add_swh_choice
+
     add_daylighting_choice = OpenStudio::Measure::OSArgument::makeChoiceArgument('add_daylighting', true_false_os_vector, true)
     add_daylighting_choice.setDisplayName('Add Daylighting')
     add_daylighting_choice.setDefaultValue('FALSE')
@@ -149,13 +155,15 @@ class CreateTypicalBuilding < OpenStudio::Measure::ModelMeasure
     add_constructions = runner.getStringArgumentValue('add_constructions', user_arguments)
     wall_construction = runner.getStringArgumentValue('wall_construction', user_arguments)
     add_space_type_loads = runner.getStringArgumentValue('add_space_type_loads', user_arguments)
+    add_swh = runner.getStringArgumentValue('add_swh', user_arguments)
     add_daylighting = runner.getStringArgumentValue('add_daylighting', user_arguments)
 
     # Convert strings to booleans
     add_constructions = add_constructions == 'TRUE'
     add_space_type_loads = add_space_type_loads == 'TRUE'
+    add_swh = add_swh == 'TRUE'
     add_daylighting = add_daylighting == 'TRUE'
-	
+
     # Convert CZ7 and CZ8 to values that OSSTD will understand (dropdown and OSSTD are different)
     climate_zone = 'ASHRAE 169-2013-7A' if climate_zone == 'ASHRAE 169-2013-7'
     climate_zone = 'ASHRAE 169-2013-8A' if climate_zone == 'ASHRAE 169-2013-8'
@@ -182,6 +190,7 @@ class CreateTypicalBuilding < OpenStudio::Measure::ModelMeasure
     runner.registerInfo("Add Constructions?: #{add_constructions}")
     runner.registerInfo("Wall Construction: #{wall_construction}")
     runner.registerInfo("Add Space Type Loads?: #{add_space_type_loads}")
+    runner.registerInfo("Add Service Water Heating?: #{add_swh}")
     runner.registerInfo("Add Daylighting?: #{add_daylighting}")
 
     # Toggle whether or not to add hvac

--- a/openstudio-building-energy-standard-measures.gemspec
+++ b/openstudio-building-energy-standard-measures.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'rubocop', '~> 1.50'
 
     spec.add_dependency 'openstudio-extension', '~> 0.8.1'
-    spec.add_dependency 'openstudio-standards', '~> 0.6.3'
+    spec.add_dependency 'openstudio-standards', '~> 0.8.2'
     spec.add_dependency 'openstudio_measure_tester', '~> 0.4.0'
   end
 end

--- a/openstudio-building-energy-standard-measures.gemspec
+++ b/openstudio-building-energy-standard-measures.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
     spec.add_development_dependency 'rubocop', '~> 1.50'
 
     spec.add_dependency 'openstudio-extension', '~> 0.8.1'
-    spec.add_dependency 'openstudio-standards', '~> 0.8.2'
+    spec.add_dependency 'openstudio-standards', '~> 0.6.3'
     spec.add_dependency 'openstudio_measure_tester', '~> 0.4.0'
   end
 end


### PR DESCRIPTION
These updates allow the create typical building measure to work with OpenStudio 3.10 and its corresponding application. In addition to that, it adds SHW as an option in the measure.